### PR TITLE
remove --target arg, allow to pass any clang arg instead

### DIFF
--- a/sys/tool/src/main.rs
+++ b/sys/tool/src/main.rs
@@ -60,7 +60,7 @@ where
 
 fn main() {
     let matches = clap::App::new("systool")
-        .author("© 2020 Amaury 'Yruama_Lairba' Abrail, Jan-Oliver 'Janonard' Opdenhövel")
+        .author("© 2020 Amaury 'Yruama_Lairba' Abrial, Jan-Oliver 'Janonard' Opdenhövel")
         .about("Generate Rust bindings of the LV2 C API")
         .version("0.1.0")
         .arg(


### PR DESCRIPTION
Hi, i did a modification to be able to pass any flag to clang. It's needed because some targets need specific flags when cross compiling.